### PR TITLE
Update AppCompat library (version 1.0.2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-android:1.7.25'
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 
     implementation 'com.android.volley:volley:1.1.0'
 }


### PR DESCRIPTION
See : https://developer.android.com/jetpack/androidx/androidx-rn#2018-nov-7

> ## November 7, 2018
> 
> Bugfix release of core-1.0.1 and appcompat-1.0.2.
> 
> ### Bug fixes
> 
> Fixed bug where PrecomputedTextCompat would crash when used with RTL AppCompatTextView. b/113070424

